### PR TITLE
Imagick dependency eliminated

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,16 +34,6 @@ To use the SDK you need to check for the following prerequisites:
             * Run `brew install composer`.
             * If you get a message that the lock file is out of date, run `brew update composer`.
   
-  3. The SDK requires [ImageMagick](https://www.imagemagick.org/script/index.php) be installed on your system, and you will need the ImageMagick PHP extension as well. Once installed, this command should print a "1," assuming you have added PHP to your global PATH:
-         `php -r "print(class_exists('imagick'));"`
-      * On a Mac, you can install this with homebrew using following commands:
-        * Use `pecl install imagick` to get the list of available imagick extensions.
-        * If __pecl__ is not installed, you are probably using the embedded version of PHP supplied with Mac OS. Look at this [Stack Overflow response](https://stackoverflow.com/a/50529784) for a workaround to install ImageMagick and the latest version of PHP using Homebrew.
-
-      * On Windows, Refer to this [article](https://mlocati.github.io/articles/php-windows-imagick.html) or you can use [curl](http://www.queryadmin.com/1556/install-composer-curl/) for the same.
-
-      * If ImageMagick is not installed, then it will only affect the similarity (visual) search method of uploading an image. If you don't need this functionality, then you don't need to install it, but you will get warnings from Composer.
-
 ### Build Steps
   * Run `composer update` to update the composer.lock file to install new dependencies.
   * Run `composer install --no-dev` for installing the required libraries.

--- a/composer.json
+++ b/composer.json
@@ -4,8 +4,7 @@
     "license": "Apache-2.0",
     "require": {
         "php": "~7.1",
-        "guzzlehttp/guzzle": "~6.0",
-        "ext-imagick": "*"
+        "guzzlehttp/guzzle": "~6.0"
     },
     "require-dev": {
         "astock/phpcs-psr2-stock": "~1.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f9d118b3031b1610ddb75fcec3d1e953",
+    "content-hash": "9668b7360b297cf7e49b2a3f349d9d2d",
     "packages": [
         {
             "name": "guzzlehttp/guzzle",
@@ -2023,8 +2023,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "~7.1",
-        "ext-imagick": "*"
+        "php": "~7.1"
     },
     "platform-dev": []
 }

--- a/src/Utils/APIUtils.php
+++ b/src/Utils/APIUtils.php
@@ -10,7 +10,6 @@ namespace AdobeStock\Api\Utils;
 
 use \AdobeStock\Api\Core\Config as CoreConfig;
 use \AdobeStock\Api\Exception\StockApi as StockApiException;
-use \Imagick;
 
 class APIUtils
 {
@@ -19,13 +18,13 @@ class APIUtils
      * @var integer $_longest_side_maximum
      */
     private static $_longest_side_maximum = 23000;
-    
+
     /**
      * Maximum side to which image is downsampled for visual search.
      * @var integer
      */
     private static $_longest_side_downsample_to = 1000;
-    
+
     /**
      * Generates a map of commonly used headers which is used
      * for Stock API access.
@@ -36,11 +35,11 @@ class APIUtils
     public static function generateCommonAPIHeaders(CoreConfig $config, string $access_token = null) : array
     {
         $request_id = static::getUUID();
-        
+
         if ($access_token !== null) {
             $access_token = 'Bearer ' . $access_token;
         }
-        
+
         $headers = [
             'headers' => [
                 'x-api-key' => $config->getApiKey(),
@@ -63,40 +62,40 @@ class APIUtils
         $nhex_len = strlen($nhex);
         $name = uniqid(mt_rand(), true);
         $nstr = '';
-        
+
         // Convert Namespace UUID to bits
         for ($i = 0; $i < $nhex_len; $i += 2) {
             $nstr .= chr(hexdec($nhex[$i] . $nhex[$i + 1]));
         }
-        
+
         // Calculate hash value
         $hash = sha1($nstr . $name);
-        
+
         $a = array(
                 // 32 bits for "time_low"
             substr($hash, 0, 8),
-            
+
             // 16 bits for "time_mid"
             substr($hash, 8, 4),
-            
+
             // 16 bits for "time_hi_and_version",
             // four most significant bits holds version number 5
             (hexdec(substr($hash, 12, 4)) & 0x0fff) | 0x5000,
-            
+
             // 16 bits, 8 bits for "clk_seq_hi_res",
             // 8 bits for "clk_seq_low",
             // two most significant bits holds zero and one for variant DCE1.1
             (hexdec(substr($hash, 16, 4)) & 0x3fff) | 0x8000,
-            
+
             // 48 bits for "node"
             substr($hash, 20, 12),
         );
-        
+
         $uuid = vsprintf('%08s%04s%04x%04x%12s', $a);
-        
+
         return $uuid;
     }
-    
+
     /**
      * Utility method to downsample the image if image size is greater than expected size.
      * @param string $file_path Path of the image to be downsampled.
@@ -105,19 +104,70 @@ class APIUtils
     public static function downSampleImage(string $file_path) : string
     {
         $file_extension = pathinfo($file_path, PATHINFO_EXTENSION);
-        
+
         if (!preg_match('/\.(png|jpe?g|gif)$/', $file_path, $file_extension)) {
             throw StockApiException::withMessage('Only jpg, png and gifs are supported image formats');
         }
-        
-        list($original_width, $original_height) = getimagesize($file_path);
+
+        list($original_width, $original_height, $type) = getimagesize($file_path);
+
         $new_dimension = static::_calculateResizeParameters($original_width, $original_height);
-        $imagick = new \Imagick(realpath($file_path));
-        $imagick->resizeImage($new_dimension['width'], $new_dimension['height'], Imagick::FILTER_GAUSSIAN, 1);
-        
-        return $imagick->getImageBlob();
+
+        return static::resizeImage(
+            $file_path,
+            $type,
+            $original_width,
+            $original_height,
+            $new_dimension['width'],
+            $new_dimension['height']
+        );
     }
-    
+
+    /**
+     * Resize a JPEG, PNG or GIF image. Returns PNG resized image as string.
+     *
+     * @param string $filePath
+     * @param int $type
+     * @param int $originalWidth
+     * @param int $originalHeight
+     * @param int $width
+     * @param int $height
+     * @return string
+     * @throws StockApiException
+     */
+    private static function resizeImage(
+        string $filePath,
+        int $type,
+        int $originalWidth,
+        int $originalHeight,
+        int $width,
+        int $height
+    ) {
+        switch ($type) {
+            case IMAGETYPE_JPEG:
+                $image = imagecreatefromjpeg($filePath);
+                break;
+            case IMAGETYPE_PNG:
+                $image = imagecreatefrompng($filePath);
+                break;
+            case IMAGETYPE_GIF:
+                $image = imagecreatefromgif($filePath);
+                break;
+            default:
+                throw StockApiException::withMessage('Only jpg, png and gifs are supported image formats');
+                break;
+        }
+
+        $sampleImage = imagecreatetruecolor($width, $height);
+        imagecopyresampled($sampleImage, $image, 0, 0, 0, 0, $width, $height, $originalWidth, $originalHeight);
+
+        ob_start();
+        imagepng($sampleImage);
+        $blob = ob_get_clean();
+
+        return $blob;
+    }
+
     /**
      * Calculate width and height to which image to be downsampled.
      * @param int $original_width  Width of original image.
@@ -130,14 +180,14 @@ class APIUtils
         $new_dimension = [];
         $new_dimension['width'] = 0;
         $new_dimension['height'] = 0;
-        
+
         if (max($original_width, $original_height) > static::$_longest_side_maximum) {
             throw StockApiException::withMessage('Image is too large for visual search!');
         } else {
             $aspect_ratio = $original_width / $original_height;
-            
+
             if ($original_width > $original_height) {
-                
+
                 if ($original_width > static::$_longest_side_downsample_to) {
                     $new_dimension['width'] = static::$_longest_side_downsample_to;
                     $new_dimension['height'] = static::$_longest_side_downsample_to / $aspect_ratio;
@@ -147,15 +197,15 @@ class APIUtils
                 $new_dimension['height'] = static::$_longest_side_downsample_to;
             }
         }
-        
+
         if ($new_dimension['width'] == 0) {
             $new_dimension['width'] = $original_width;
         }
-        
+
         if ($new_dimension['height'] == 0) {
             $new_dimension['height'] = $original_height;
         }
-        
+
         return $new_dimension;
     }
 }


### PR DESCRIPTION
Imagick dependency is used only for resize of sample image in exactly one place in the library, however, it complicates the library installation on development environments and makes it impossible to include the library to the codebase on production environments without the environment update. 

Because of the above, Imagick dependency drastically decreases the number of users willing to utilize this library.

This pull request replaces Imagick with native PHP functions, provides an improvement and refactoring to the corresponding test.