### PR TITLE
fixed search with 0

### DIFF
--- a/src/Models/SearchParameters.php
+++ b/src/Models/SearchParameters.php
@@ -509,14 +509,9 @@ class SearchParameters
      * Sets keywords in search Params for searching files.
      * @param string $words keywords that you want to search
      * @return SearchParameters object
-     * @throws StockApiException if words is null or blank
      */
     public function setWords(string $words) : SearchParameters
     {
-        if (empty($words)) {
-            throw StockApiException::WithMessage('Should not be blank or null values in kewywords field');
-        }
-        
         $this->words = $words;
         return $this;
     }


### PR DESCRIPTION
If I want to search by 0 I get errors "Should not be blank or null values in kewywords field". I fixed it.