### PR TITLE
Fixed bug when access token was set to incorrect property when searching files

### DIFF
--- a/src/Client/SearchFiles.php
+++ b/src/Client/SearchFiles.php
@@ -371,7 +371,7 @@ class SearchFiles
             array_push($this->_current_request->result_columns, 'nb_results');
         }
         
-        $this->access_token = $access_token;
+        $this->_access_token = $access_token;
         $this->_api_in_progress = false;
         $this->_http_client = $http_client;
         

--- a/src/Client/SearchFiles.php
+++ b/src/Client/SearchFiles.php
@@ -133,7 +133,7 @@ class SearchFiles
     public function getFiles(SearchFilesRequest $search_file_request, string $access_token = null) : SearchFilesResponse
     {
         $this->_http_method = $this->_getHttpMethod($search_file_request);
-        $headers = APIUtils::generateCommonAPIHeaders($this->_config, null);
+        $headers = APIUtils::generateCommonAPIHeaders($this->_config, $access_token);
         $end_point = $this->_config->getEndPoints()['search'];
         $request_url = $end_point . '?' . http_build_query($search_file_request);
         

--- a/test/src/Api/Models/SearchParametersTest.php
+++ b/test/src/Api/Models/SearchParametersTest.php
@@ -117,13 +117,13 @@ class SearchParametersTest extends TestCase
     
     /**
      * @test
-     * @expectedException \AdobeStock\Api\Exception\StockApi
+     * @expectedException \TypeError
      */
     public function testWords()
     {
         $this->search_params->setWords('Tree');
         $this->assertEquals('Tree', $this->search_params->getWords());
-        $this->search_params->setWords('');
+        $this->search_params->setWords(null);
     }
     
     /**


### PR DESCRIPTION
Fixed bug when access token was set to incorrect property

The `$_access_token` property is declared in the `SearchFiles` class:  https://github.com/adobe/stock-api-libphp/blob/dd2d2a887e3db8b0d37ea5c1f1933894b6e134c1/src/Client/SearchFiles.php#L45

Also `$_access_token` property is used for search results retrieval: https://github.com/adobe/stock-api-libphp/blob/dd2d2a887e3db8b0d37ea5c1f1933894b6e134c1/src/Client/SearchFiles.php#L210

However, the access token is actually set to `$access_token` property in `searchFilesInitialize` function: https://github.com/adobe/stock-api-libphp/blob/dd2d2a887e3db8b0d37ea5c1f1933894b6e134c1/src/Client/SearchFiles.php#L374

That results into SDK not able to search files in authorization context (as access token is always `null`), so clients are unable to retrieve information like `is_licensed`