### PR TITLE
Enhance Travis CI setting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: php
 php:
+ - 7.1
  - 7.2
+ - 7.3
 install: composer install
 script: composer run test

--- a/test/bootstrap.php
+++ b/test/bootstrap.php
@@ -6,5 +6,5 @@
  * of the License at http://www.apache.org/licenses/LICENSE-2.0
  */
 error_reporting(-1); // Show them all
-$root_directory = realpath(dirname(__FILE__) . '/../') . '/';
-require($root_directory . 'vendor/autoload.php');
+
+require_once __DIR__ . '/../vendor/autoload.php';


### PR DESCRIPTION
## Overview
- Using the `__DIR__` to load required classes automatically
- Add the `php-7.1` and `php-7.3` tests on Travis CI build.

## Technical Changes
<A list of code changes made in this PR>
 - Enhance Travis CI build setting