### PR TITLE
Implemented Files API

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,6 +339,72 @@ It represents the search result returned from Stock Search/Category API. The `Ad
 * `getId` - Get unique identifier of the category returned by search/category API
 * `getLink` - Get path of the category returned by search/category API
 
+### Accessing Files Metadata
+#### Files
+`AdobeStock` class allows you to access the Files Stock APIs. The Files API is used to retrieve metadata from Adobe Stock, either one asset at a time, or in bulk.
+
+ You can construct the `FilesRequest` object to set identifiers, locale information and desired result columns. Then you can call `getFiles` method to get metadata about the requested file ids in the form of `FilesResponse` object.
+
+##### Instantiation
+You can construct the object of this class with below arguments -
+
+* Requires:
+    `config` - the stock configuration object of `Config` type.
+   
+* Returns:
+    `FilesResponse` - The response object containing the files API results matching the request object, returned by `getFiles` method.
+
+##### Example
+Sample code to instantiate the Files API -
+
+``` PHP
+
+        //Instantiating and Initializing AdobeStock
+        $client = new AdobeStock('AdobeStockClient1', 'Adobe Stock Lib/1.0.0', 'PROD', new Http());
+        //Users ims token
+        $access_token = 'ims_token';
+
+        //Constructing SearchCategoryRequest
+        $request = new FilesRequest();
+        $request->setIds([105988, 105989, 105990])
+                ->setLocale('En-US');
+                ->setsetResultColumns([
+                    'id',
+                    'title',
+                    'creator_name',
+                    'description',
+                ]);
+
+        //Now you can call getFiles to get files metadata
+        $response = $client->getFiles($request, $access_token);
+
+```
+##### Methods
+* `AdobeStock` class methods can throw StockApiException if request is not valid or API returns with an error. It allows you to -
+   * `getFiles` - Method to get metadata information about Stock Files. You need to pass `FilesRequest` object containing files identifiers, locale(optional) and result_columns(optional) parameters. If the request object is not valid or API returns with error, the method will throw the `StockApiException`.
+
+#### FilesRequest
+In order to make GetFiles API call, you need to create a `FilesRequest` object to define the ids of the files that you are looking for metadata. You can set files identifiers, location language code and result columns supported by Bulk metadata Files API.
+
+Here is the mapping of Files API query parameters with the setters methods that you can use to set the corresponding parameters in PHP Stock SDK -
+
+|API URL Query Parameter| Setter Methods in SearchCategoryRequest |Description|
+|---|---|---|
+|ids|setIds|Sets an array of files identifiers e.g array(105988)|
+|locale|setLocale|Sets location language code. For e.g. "en-US", "fr-FR" etc.|
+|result_columns|setResultColumns|Sets an array of requested metadata e.g array('id','title',...)|
+
+##### Note
+If you are not setting result columns, it will set following columns in result_columns array by default.
+* Default Result Columns -
+    * `ID`
+
+#### FilesResponse
+It represents the result returned from Files API. The `AdobeStock` class methods for e.g. `getFiles` returns the object of `FilesResponse` initialized with the results returned from the Files API.
+`FilesResponse` allows you to -
+* `getNbResults` - Get the value of 'nb_results' column from the Files response
+* `getFiles` - Get the list of `StockFile` returned by Files api
+
 ### Accessing License 
 ##### License
 `License` class allows you to purchase an asset, information about purchasing the asset, information about a user's licensing (entitlement) status, determine whether the user has an existing license for an asset,for notifying the system when a user     abandons a licensing operation, request a license for an asset for that user if user have authorization for licensing assets and fetch the URL of the asset if it is already licensed.

--- a/README.md
+++ b/README.md
@@ -343,7 +343,7 @@ It represents the search result returned from Stock Search/Category API. The `Ad
 #### Files
 `AdobeStock` class allows you to access the Files Stock APIs. The Files API is used to retrieve metadata from Adobe Stock, either one asset at a time, or in bulk.
 
- You can construct the `FilesRequest` object to set identifiers, locale information and desired result columns. Then you can call `getFiles` method to get metadata about the requested file ids in the form of `FilesResponse` object.
+ You can construct the `\AdobeStock\Api\Request\Files` object to set identifiers, locale information and desired result columns. Then you can call `getFiles` method to get metadata about the requested file ids in the form of `\AdobeStock\Api\Response\Files` object.
 
 ##### Instantiation
 You can construct the object of this class with below arguments -
@@ -352,7 +352,7 @@ You can construct the object of this class with below arguments -
     `config` - the stock configuration object of `Config` type.
    
 * Returns:
-    `FilesResponse` - The response object containing the files API results matching the request object, returned by `getFiles` method.
+    `\AdobeStock\Api\Response\Files` - The response object containing the files API results matching the request object, returned by `getFiles` method.
 
 ##### Example
 Sample code to instantiate the Files API -
@@ -365,10 +365,10 @@ Sample code to instantiate the Files API -
         $access_token = 'ims_token';
 
         //Constructing SearchCategoryRequest
-        $request = new FilesRequest();
+        $request = new \AdobeStock\Api\Request\Files();
         $request->setIds([105988, 105989, 105990])
                 ->setLocale('En-US');
-                ->setsetResultColumns([
+                ->setResultColumns([
                     'id',
                     'title',
                     'creator_name',
@@ -381,10 +381,10 @@ Sample code to instantiate the Files API -
 ```
 ##### Methods
 * `AdobeStock` class methods can throw StockApiException if request is not valid or API returns with an error. It allows you to -
-   * `getFiles` - Method to get metadata information about Stock Files. You need to pass `FilesRequest` object containing files identifiers, locale(optional) and result_columns(optional) parameters. If the request object is not valid or API returns with error, the method will throw the `StockApiException`.
+   * `getFiles` - Method to get metadata information about Stock Files. You need to pass `\AdobeStock\Api\Request\Files` object containing files identifiers, locale(optional) and result_columns(optional) parameters. If the request object is not valid or API returns with error, the method will throw the `StockApiException`.
 
 #### FilesRequest
-In order to make GetFiles API call, you need to create a `FilesRequest` object to define the ids of the files that you are looking for metadata. You can set files identifiers, location language code and result columns supported by Bulk metadata Files API.
+In order to make GetFiles API call, you need to create a `\AdobeStock\Api\Request\Files` object to define the ids of the files that you are looking for metadata. You can set files identifiers, location language code and result columns supported by Bulk metadata Files API.
 
 Here is the mapping of Files API query parameters with the setters methods that you can use to set the corresponding parameters in PHP Stock SDK -
 
@@ -400,8 +400,8 @@ If you are not setting result columns, it will set following columns in result_c
     * `ID`
 
 #### FilesResponse
-It represents the result returned from Files API. The `AdobeStock` class methods for e.g. `getFiles` returns the object of `FilesResponse` initialized with the results returned from the Files API.
-`FilesResponse` allows you to -
+It represents the result returned from Files API. The `AdobeStock` class methods for e.g. `getFiles` returns the object of `\AdobeStock\Api\Response\Files` initialized with the results returned from the Files API.
+`\AdobeStock\Api\Response\Files` allows you to -
 * `getNbResults` - Get the value of 'nb_results' column from the Files response
 * `getFiles` - Get the list of `StockFile` returned by Files api
 

--- a/src/Client/AdobeStock.php
+++ b/src/Client/AdobeStock.php
@@ -10,7 +10,7 @@ namespace AdobeStock\Api\Client;
 
 use \AdobeStock\Api\Client\SearchCategory as SearchCategoryFactory;
 use \AdobeStock\Api\Core\Config as CoreConfig;
-use AdobeStock\Api\Exception\StockApi as StockApiException;
+use \AdobeStock\Api\Exception\StockApi as StockApiException;
 use \AdobeStock\Api\Request\SearchCategory as SearchCategoryRequest;
 use \AdobeStock\Api\Response\SearchCategory as SearchCategoryResponse;
 use \AdobeStock\Api\Client\Http\HttpInterface;
@@ -28,6 +28,7 @@ use \AdobeStock\Api\Response\LicenseHistory as LicenseHistoryResponse;
 
 class AdobeStock
 {
+
     /**
      * Configuration that needs to be initialized.
      * @var CoreConfig
@@ -45,19 +46,19 @@ class AdobeStock
      * @var SearchFiles
      */
     private $_search_files_factory;
-
+    
     /**
      * Factory object of all license apis.
      * @var LicenseFactory;
      */
     private $_license_factory;
-
+    
     /**
      * Factory object of all files apis.
      * @var Files;
      */
     private $_files_factory;
-
+    
     /**
      * Factory object of all license History apis.
      * @var LicenseHistory
@@ -229,7 +230,7 @@ class AdobeStock
         $current_page = $this->_search_files_factory->currentSearchPageIndex();
         return $current_page;
     }
-
+    
     /**
      * Requests licensing information about a specific asset for a specific user
      * @param LicenseRequest $request      object containing
@@ -242,7 +243,7 @@ class AdobeStock
         $response = $this->_license_factory->getContentInfo($request, $access_token, $this->_http_client);
         return $response;
     }
-
+    
     /**
      * Requests a license for an asset for a specific user.
      * @param LicenseRequest $request
@@ -254,7 +255,7 @@ class AdobeStock
         $response = $this->_license_factory->getContentLicense($request, $access_token, $this->_http_client);
         return $response;
     }
-
+    
     /**
      * It can be used to get the licensing capabilities for a specific user.
      * This API returns the user's available purchase quota, the member
@@ -273,7 +274,7 @@ class AdobeStock
         $response = $this->_license_factory->getMemberProfile($request, $access_token, $this->_http_client);
         return $response;
     }
-
+    
     /**
      * Notifies the system when a user cancels a licensing operation.
      * It can be used if the user refuses the opportunity to purchase
@@ -287,7 +288,7 @@ class AdobeStock
         $response_code = $this->_license_factory->abandonLicense($request, $access_token, $this->_http_client);
         return $response_code;
     }
-
+    
     /**
      * Provide the guzzle request object that contains url of the asset that can be downloaded by hitting request with guzzle client send method if it is already licensed
      * @param LicenseRequest $request
@@ -299,7 +300,7 @@ class AdobeStock
         $guzzle_request = $this->_license_factory->downloadAssetRequest($request, $access_token, $this->_http_client);
         return $guzzle_request;
     }
-
+    
     /**
      * Provide the url of the asset if it is already licensed.
      * @param LicenseRequest $request
@@ -311,7 +312,7 @@ class AdobeStock
         $url = $this->_license_factory->downloadAssetUrl($request, $access_token, $this->_http_client);
         return $url;
     }
-
+    
     /**
      * Provide the Image Buffer if it is already licensed.
      * @param LicenseRequest $request
@@ -335,7 +336,7 @@ class AdobeStock
         $this->_license_history_factory->initializeLicenseHistory($request, $access_token, $this->_http_client);
         return $this;
     }
-
+    
     /**
      * Method to get next license history files response page.
      * @return LicenseHistoryResponse
@@ -345,7 +346,7 @@ class AdobeStock
         $response = $this->_license_history_factory->getNextLicenseHistory();
         return $response;
     }
-
+    
     /**
      * Method to get previous license history files response page.
      * @return LicenseHistoryResponse
@@ -355,7 +356,7 @@ class AdobeStock
         $response = $this->_license_history_factory->getPreviousLicenseHistory();
         return $response;
     }
-
+    
     /**
      * Method to get response from last api call.
      * @return LicenseHistoryResponse
@@ -365,7 +366,7 @@ class AdobeStock
         $response = $this->_license_history_factory->getLastLicenseHistory();
         return $response;
     }
-
+    
     /**
      * Method to skip to a specific license files response page.
      * @param int $page_index
@@ -376,7 +377,7 @@ class AdobeStock
         $response = $this->_license_history_factory->getLicenseHistoryPage($page_index);
         return $response;
     }
-
+    
     /**
      * Method to get total license files available.
      * @return int
@@ -386,7 +387,7 @@ class AdobeStock
         $total_files = $this->_license_history_factory->getTotalLicenseHistoryFiles();
         return $total_files;
     }
-
+    
     /**
      * Method to get total license results pages.
      * @return int
@@ -396,7 +397,7 @@ class AdobeStock
         $total_pages = $this->_license_history_factory->getTotalLicenseHistoryPages();
         return $total_pages;
     }
-
+    
     /**
      * Method to get response from last api call.
      * @return int
@@ -406,6 +407,4 @@ class AdobeStock
         $current_page = $this->_license_history_factory->currentLicenseHistoryPageIndex();
         return $current_page;
     }
-
-
 }

--- a/src/Client/AdobeStock.php
+++ b/src/Client/AdobeStock.php
@@ -10,11 +10,14 @@ namespace AdobeStock\Api\Client;
 
 use \AdobeStock\Api\Client\SearchCategory as SearchCategoryFactory;
 use \AdobeStock\Api\Core\Config as CoreConfig;
+use AdobeStock\Api\Exception\StockApi as StockApiException;
 use \AdobeStock\Api\Request\SearchCategory as SearchCategoryRequest;
 use \AdobeStock\Api\Response\SearchCategory as SearchCategoryResponse;
 use \AdobeStock\Api\Client\Http\HttpInterface;
 use \AdobeStock\Api\Request\SearchFiles as SearchFilesRequest;
 use \AdobeStock\Api\Response\SearchFiles as SearchFilesResponse;
+use \AdobeStock\Api\Request\Files as FilesRequest;
+use \AdobeStock\Api\Response\Files as FilesResponse;
 use \AdobeStock\Api\Client\Http\HttpClient;
 use \AdobeStock\Api\Request\License as LicenseRequest;
 use \AdobeStock\Api\Client\License as LicenseFactory;
@@ -25,7 +28,6 @@ use \AdobeStock\Api\Response\LicenseHistory as LicenseHistoryResponse;
 
 class AdobeStock
 {
-
     /**
      * Configuration that needs to be initialized.
      * @var CoreConfig
@@ -43,13 +45,19 @@ class AdobeStock
      * @var SearchFiles
      */
     private $_search_files_factory;
-    
+
     /**
      * Factory object of all license apis.
      * @var LicenseFactory;
      */
     private $_license_factory;
-    
+
+    /**
+     * Factory object of all files apis.
+     * @var Files;
+     */
+    private $_files_factory;
+
     /**
      * Factory object of all license History apis.
      * @var LicenseHistory
@@ -77,6 +85,7 @@ class AdobeStock
         $this->_search_files_factory = new SearchFiles($this->_config);
         $this->_license_factory = new LicenseFactory($this->_config);
         $this->_license_history_factory = new LicenseHistory($this->_config);
+        $this->_files_factory = new Files($this->_config);
 
         if ($http_client === null) {
             $this->_http_client = new HttpClient();
@@ -123,6 +132,19 @@ class AdobeStock
     {
         $response = $this->_search_category_factory->getCategoryTree($request, $access_token, $this->_http_client);
         return $response;
+    }
+
+    /**
+     * Method to get files using API.
+     *
+     * @param FilesRequest $request
+     * @param string $access_token
+     * @return FilesResponse
+     * @throws StockApiException
+     */
+    public function getFiles(FilesRequest $request, string $access_token = null) : FilesResponse
+    {
+        return $this->_files_factory->getFiles($request, $this->_http_client, $access_token);
     }
 
     /**
@@ -207,7 +229,7 @@ class AdobeStock
         $current_page = $this->_search_files_factory->currentSearchPageIndex();
         return $current_page;
     }
-    
+
     /**
      * Requests licensing information about a specific asset for a specific user
      * @param LicenseRequest $request      object containing
@@ -220,7 +242,7 @@ class AdobeStock
         $response = $this->_license_factory->getContentInfo($request, $access_token, $this->_http_client);
         return $response;
     }
-    
+
     /**
      * Requests a license for an asset for a specific user.
      * @param LicenseRequest $request
@@ -232,7 +254,7 @@ class AdobeStock
         $response = $this->_license_factory->getContentLicense($request, $access_token, $this->_http_client);
         return $response;
     }
-    
+
     /**
      * It can be used to get the licensing capabilities for a specific user.
      * This API returns the user's available purchase quota, the member
@@ -251,7 +273,7 @@ class AdobeStock
         $response = $this->_license_factory->getMemberProfile($request, $access_token, $this->_http_client);
         return $response;
     }
-    
+
     /**
      * Notifies the system when a user cancels a licensing operation.
      * It can be used if the user refuses the opportunity to purchase
@@ -265,7 +287,7 @@ class AdobeStock
         $response_code = $this->_license_factory->abandonLicense($request, $access_token, $this->_http_client);
         return $response_code;
     }
-    
+
     /**
      * Provide the guzzle request object that contains url of the asset that can be downloaded by hitting request with guzzle client send method if it is already licensed
      * @param LicenseRequest $request
@@ -277,7 +299,7 @@ class AdobeStock
         $guzzle_request = $this->_license_factory->downloadAssetRequest($request, $access_token, $this->_http_client);
         return $guzzle_request;
     }
-    
+
     /**
      * Provide the url of the asset if it is already licensed.
      * @param LicenseRequest $request
@@ -289,7 +311,7 @@ class AdobeStock
         $url = $this->_license_factory->downloadAssetUrl($request, $access_token, $this->_http_client);
         return $url;
     }
-    
+
     /**
      * Provide the Image Buffer if it is already licensed.
      * @param LicenseRequest $request
@@ -313,7 +335,7 @@ class AdobeStock
         $this->_license_history_factory->initializeLicenseHistory($request, $access_token, $this->_http_client);
         return $this;
     }
-    
+
     /**
      * Method to get next license history files response page.
      * @return LicenseHistoryResponse
@@ -323,7 +345,7 @@ class AdobeStock
         $response = $this->_license_history_factory->getNextLicenseHistory();
         return $response;
     }
-    
+
     /**
      * Method to get previous license history files response page.
      * @return LicenseHistoryResponse
@@ -333,7 +355,7 @@ class AdobeStock
         $response = $this->_license_history_factory->getPreviousLicenseHistory();
         return $response;
     }
-    
+
     /**
      * Method to get response from last api call.
      * @return LicenseHistoryResponse
@@ -343,7 +365,7 @@ class AdobeStock
         $response = $this->_license_history_factory->getLastLicenseHistory();
         return $response;
     }
-    
+
     /**
      * Method to skip to a specific license files response page.
      * @param int $page_index
@@ -354,7 +376,7 @@ class AdobeStock
         $response = $this->_license_history_factory->getLicenseHistoryPage($page_index);
         return $response;
     }
-    
+
     /**
      * Method to get total license files available.
      * @return int
@@ -364,7 +386,7 @@ class AdobeStock
         $total_files = $this->_license_history_factory->getTotalLicenseHistoryFiles();
         return $total_files;
     }
-    
+
     /**
      * Method to get total license results pages.
      * @return int
@@ -374,7 +396,7 @@ class AdobeStock
         $total_pages = $this->_license_history_factory->getTotalLicenseHistoryPages();
         return $total_pages;
     }
-    
+
     /**
      * Method to get response from last api call.
      * @return int
@@ -384,4 +406,6 @@ class AdobeStock
         $current_page = $this->_license_history_factory->currentLicenseHistoryPageIndex();
         return $current_page;
     }
+
+
 }

--- a/src/Client/Files.php
+++ b/src/Client/Files.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * Copyright 2017 Adobe Systems Incorporated. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+namespace AdobeStock\Api\Client;
+
+use \AdobeStock\Api\Exception\StockApi as StockApiException;
+use \AdobeStock\Api\Core\Config as CoreConfig;
+use \AdobeStock\Api\Client\Http\HttpInterface as HttpClientInterface;
+use \AdobeStock\Api\Utils\APIUtils;
+use \AdobeStock\Api\Request\Files as FilesRequest;
+use \AdobeStock\Api\Response\Files as FilesResponse;
+use function \GuzzleHttp\json_decode;
+
+class Files
+{
+    /**
+     * @var CoreConfig configuration that need to be initialized
+     * before calling apis.
+     */
+    private $_config;
+
+    /**
+     * Constructor.
+     * @param CoreConfig $config config to be initialized.
+     */
+    public function __construct(CoreConfig $config)
+    {
+        $this->_config = $config;
+    }
+
+    /**
+     * Method to create and send request to the apis and parse result to response object.
+     *
+     * @param FilesRequest $file_request object containing files request parameters
+     * @param HttpClientInterface $http_client
+     * @param string $access_token access token string to be used with api calls
+     * @return FilesResponse response object from the api call
+     * @throws StockApiException
+     */
+    public function getFiles(
+        FilesRequest $file_request,
+        HttpClientInterface $http_client,
+        string $access_token = null
+    ) : FilesResponse {
+        $this->_validateRequest($file_request, $access_token);
+        $response_json = $http_client->doGet(
+            $this->_getUrl($file_request),
+            APIUtils::generateCommonAPIHeaders($this->_config, $access_token)
+        );
+        $files_response = new FilesResponse();
+        $files_response->initializeResponse(json_decode($response_json, true));
+        return $files_response;
+    }
+
+    /**
+     * Method to validate request.
+     *
+     * @param FilesRequest $request
+     * @param string $access_token
+     * @throws StockApiException
+     */
+    private function _validateRequest(FilesRequest $request, string $access_token = null) : void
+    {
+        if (!empty($request->getResultColumns())) {
+            if (in_array('is_licensed', $request->getResultColumns()) && $access_token === null) {
+                throw StockApiException::withMessage(
+                    'Access Token missing! Result Column is_licensed requires authentication'
+                );
+            }
+        }
+    }
+
+    /**
+     * Build request URL with parameters
+     *
+     * @param FilesRequest $filesRequest
+     * @return string
+     */
+    private function _getUrl(FilesRequest $filesRequest) : string
+    {
+        return $this->_config->getEndPoints()['files'] . '?' . http_build_query($filesRequest->toArray());
+    }
+}

--- a/src/Core/Constants.php
+++ b/src/Core/Constants.php
@@ -14,13 +14,14 @@ class Constants
      * @var array Query params
      */
     protected static $_queryParamsProps = [
+        'IDS' => 'ids',
         'LOCALE' => 'locale',
         'SEARCH_PARAMETERS' => 'search_parameters',
         'RESULT_COLUMNS' => 'result_columns',
         'SIMILAR_IMAGE' => 'similar_image',
         'CATEGORY' => 'category_id',
     ];
-    
+
     /**
      * @var array end points.
      */
@@ -33,6 +34,7 @@ class Constants
         'user_profile' => 'https://stock.adobe.io/Rest/Libraries/1/Member/Profile',
         'abandon' => 'https://stock.adobe.io/Rest/Libraries/1/Member/Abandon',
         'license_history' => 'https://stock.adobe.io/Rest/Libraries/1/Member/LicenseHistory',
+        'files' => 'https://stock.adobe.io/Rest/Media/1/Files'
     ];
 
     /**
@@ -42,7 +44,7 @@ class Constants
         'GET' => 'GET',
         'POST' => 'POST',
     ];
-    
+
     /**
      * @var array Environment
      */
@@ -50,7 +52,7 @@ class Constants
         'PROD' => 'PROD',
         'STAGE' => 'STAGE',
     ];
-    
+
     /**
      * @var array searchParamsOrders
      */
@@ -61,7 +63,7 @@ class Constants
         'NB_DOWNLOADS' => 'nb_downloads',
         'UNDISCOVERED' => 'undiscovered',
     ];
-    
+
     /**
      * @var array searchParamsOrientation
      */
@@ -71,7 +73,7 @@ class Constants
         'SQUARE' => 'square',
         'ALL' => 'all',
     ];
-    
+
     /**
      * @var array searchParamsOrientation
      */
@@ -80,7 +82,7 @@ class Constants
         'FALSE' => 'false',
         'ALL' => 'all',
     ];
-    
+
     /**
      * @var array searchParams3DTypes
      */
@@ -89,7 +91,7 @@ class Constants
         'LIGHTS' => 2,
         'MATERIALS' => 3,
     ];
-    
+
     /**
      * @var array Query searchParamsTemplateCategories
      */
@@ -101,7 +103,7 @@ class Constants
         'FILM' => 5,
         'ART' => 6,
     ];
-    
+
     /**
      * @var array searchParamsTemplateCategories
      */
@@ -109,7 +111,7 @@ class Constants
         'PSDT' => 1,
         'AIT' => 2,
     ];
-    
+
     /**
      * @var array searchParamsThumbSizes
      */
@@ -119,7 +121,7 @@ class Constants
         'XL' => 500,
         'XXL' => 1000,
     ];
-    
+
     /**
      * @var array Query searchParamsAge
      */
@@ -131,7 +133,7 @@ class Constants
         'TWO_YEAR' => '2y',
         'ALL' => 'all',
     ];
-    
+
     /**
      * @var array Query searchParamsVideoDuration
      */
@@ -142,7 +144,7 @@ class Constants
         'ABOVE_THIRTY' => '30-',
         'ALL' => 'all',
     ];
-    
+
     /**
      * @var array Query searchParamsType
      */
@@ -152,7 +154,7 @@ class Constants
         'RANGE' => 2,
         'ARRAY' => 3,
     ];
-    
+
     /**
      * @var array Query searchParamsPremium
      */
@@ -161,7 +163,7 @@ class Constants
         'FALSE' => 'false',
         'ALL' => 'all',
     ];
-    
+
     /**
      * @var array Query resultColumns
      */
@@ -235,7 +237,7 @@ class Constants
         'VIDEO_SMALL_PREVIEW_CONTENT_TYPE' => 'video_small_preview_content_type',
         'IS_EDITORIAL' => 'is_editorial',
     ];
-    
+
     /**
      * @var array Query licenseStateParams
      */
@@ -247,7 +249,7 @@ class Constants
         'STANDARD_M' => 'Standard_M',
         'EMPTY' => '',
     ];
-    
+
     /**
      * @var array Asset type id
      */
@@ -260,7 +262,7 @@ class Constants
         'THREE_DIMENSIONAL' => 6,
         'TEMPLATES' => 7,
     ];
-    
+
     /**
      * @var array Assest premium level id
      */
@@ -271,7 +273,7 @@ class Constants
         'PREMIUM2' => 3,
         'PREMIUM3' => 4,
     ];
-    
+
     /**
      * @var array Query purchaseStateParams
      */
@@ -283,7 +285,7 @@ class Constants
         'JUST_PURCHASED' => 'just_purchased',
         'OVERAGE' => 'overage',
     ];
-    
+
     /**
      * The size of the asset, indicating whether it is the free
      * complementary size or the original full-sized asset.
@@ -293,7 +295,7 @@ class Constants
         'Comp' => 'Comp',
         'Original' => 'Original',
     ];
-    
+
     /**
      * @var array searchParamLicenseThumbSizes
      */
@@ -314,7 +316,7 @@ class Constants
     {
         return static::$_queryParamsProps;
     }
-    
+
     /**
      * Getter for HttpMethod.
      * @return array
@@ -323,7 +325,7 @@ class Constants
     {
         return static::$_http_method;
     }
-    
+
     /**
      * Getter for Environment.
      * @return array
@@ -332,7 +334,7 @@ class Constants
     {
         return static::$_environments;
     }
-    
+
     /**
      * Getter for EndPoints.
      * @return array
@@ -341,7 +343,7 @@ class Constants
     {
         return static::$_end_points;
     }
-    
+
     /**
      * Getter for Asset Premium level.
      * @return array
@@ -350,7 +352,7 @@ class Constants
     {
         return static::$_assetPremiumLevel;
     }
-    
+
     /**
      * Getter for Asset Type.
      * @return array
@@ -368,7 +370,7 @@ class Constants
     {
         return static::$_searchParamsOrders;
     }
-    
+
     /**
      * Getter for SearchParamsOrientation.
      * @return array
@@ -377,7 +379,7 @@ class Constants
     {
         return static::$_searchParamsOrientation;
     }
-    
+
     /**
      * Getter for SearchParamsHasReleases.
      * @return array
@@ -386,7 +388,7 @@ class Constants
     {
         return static::$_SearchParamsHasReleases;
     }
-    
+
     /**
      * Getter for SearchParams3DTypes.
      * @return string
@@ -395,7 +397,7 @@ class Constants
     {
         return static::$_searchParams3DTypes;
     }
-    
+
     /**
      * Getter for SearchParamsTemplateCategories.
      * @return array
@@ -404,7 +406,7 @@ class Constants
     {
         return static::$_searchParamsTemplateCategories;
     }
-    
+
     /**
      * Getter for Query Param Props.
      * @return array
@@ -413,7 +415,7 @@ class Constants
     {
         return static::$_searchParamsTemplateTypes;
     }
-    
+
     /**
      * Getter for SearchParamsThumbSizes.
      * @return array
@@ -422,7 +424,7 @@ class Constants
     {
         return static::$_searchParamsThumbSizes;
     }
-    
+
     /**
      * Getter for SearchParamsAge.
      * @return array
@@ -431,7 +433,7 @@ class Constants
     {
         return static::$_searchParamsAge;
     }
-    
+
     /**
      * Getter for SearchParamsVideoDuration.
      * @return array
@@ -440,7 +442,7 @@ class Constants
     {
         return static::$_searchParamsVideoDuration;
     }
-    
+
     /**
      * Getter for SearchParamsType.
      * @return array
@@ -449,7 +451,7 @@ class Constants
     {
         return static::$_searchParamsType;
     }
-    
+
     /**
      * Getter for SearchParamsPremium.
      * @return array
@@ -467,7 +469,7 @@ class Constants
     {
         return static::$_resultColumns;
     }
-    
+
     /**
      * Getter for LicenseStateParams.
      * @return array
@@ -476,7 +478,7 @@ class Constants
     {
         return static::$_licenseStateParams;
     }
-    
+
     /**
      * Getter for PurchaseStateParams.
      * @return array
@@ -485,7 +487,7 @@ class Constants
     {
         return static::$_purchaseStateParams;
     }
-    
+
     /**
      * Getter for assest license size.
      * @return array of asset License Size
@@ -494,7 +496,7 @@ class Constants
     {
         return static::$_asset_license_size;
     }
-    
+
     /**
      * Getter for SearchParamsThumbSizes.
      * @return array

--- a/src/Core/Constants.php
+++ b/src/Core/Constants.php
@@ -21,7 +21,7 @@ class Constants
         'SIMILAR_IMAGE' => 'similar_image',
         'CATEGORY' => 'category_id',
     ];
-
+    
     /**
      * @var array end points.
      */
@@ -44,7 +44,7 @@ class Constants
         'GET' => 'GET',
         'POST' => 'POST',
     ];
-
+    
     /**
      * @var array Environment
      */
@@ -52,7 +52,7 @@ class Constants
         'PROD' => 'PROD',
         'STAGE' => 'STAGE',
     ];
-
+    
     /**
      * @var array searchParamsOrders
      */
@@ -63,7 +63,7 @@ class Constants
         'NB_DOWNLOADS' => 'nb_downloads',
         'UNDISCOVERED' => 'undiscovered',
     ];
-
+    
     /**
      * @var array searchParamsOrientation
      */
@@ -73,7 +73,7 @@ class Constants
         'SQUARE' => 'square',
         'ALL' => 'all',
     ];
-
+    
     /**
      * @var array searchParamsOrientation
      */
@@ -82,7 +82,7 @@ class Constants
         'FALSE' => 'false',
         'ALL' => 'all',
     ];
-
+    
     /**
      * @var array searchParams3DTypes
      */
@@ -91,7 +91,7 @@ class Constants
         'LIGHTS' => 2,
         'MATERIALS' => 3,
     ];
-
+    
     /**
      * @var array Query searchParamsTemplateCategories
      */
@@ -103,7 +103,7 @@ class Constants
         'FILM' => 5,
         'ART' => 6,
     ];
-
+    
     /**
      * @var array searchParamsTemplateCategories
      */
@@ -111,7 +111,7 @@ class Constants
         'PSDT' => 1,
         'AIT' => 2,
     ];
-
+    
     /**
      * @var array searchParamsThumbSizes
      */
@@ -121,7 +121,7 @@ class Constants
         'XL' => 500,
         'XXL' => 1000,
     ];
-
+    
     /**
      * @var array Query searchParamsAge
      */
@@ -133,7 +133,7 @@ class Constants
         'TWO_YEAR' => '2y',
         'ALL' => 'all',
     ];
-
+    
     /**
      * @var array Query searchParamsVideoDuration
      */
@@ -144,7 +144,7 @@ class Constants
         'ABOVE_THIRTY' => '30-',
         'ALL' => 'all',
     ];
-
+    
     /**
      * @var array Query searchParamsType
      */
@@ -154,7 +154,7 @@ class Constants
         'RANGE' => 2,
         'ARRAY' => 3,
     ];
-
+    
     /**
      * @var array Query searchParamsPremium
      */
@@ -163,7 +163,7 @@ class Constants
         'FALSE' => 'false',
         'ALL' => 'all',
     ];
-
+    
     /**
      * @var array Query resultColumns
      */
@@ -237,7 +237,7 @@ class Constants
         'VIDEO_SMALL_PREVIEW_CONTENT_TYPE' => 'video_small_preview_content_type',
         'IS_EDITORIAL' => 'is_editorial',
     ];
-
+    
     /**
      * @var array Query licenseStateParams
      */
@@ -249,7 +249,7 @@ class Constants
         'STANDARD_M' => 'Standard_M',
         'EMPTY' => '',
     ];
-
+    
     /**
      * @var array Asset type id
      */
@@ -262,7 +262,7 @@ class Constants
         'THREE_DIMENSIONAL' => 6,
         'TEMPLATES' => 7,
     ];
-
+    
     /**
      * @var array Assest premium level id
      */
@@ -273,7 +273,7 @@ class Constants
         'PREMIUM2' => 3,
         'PREMIUM3' => 4,
     ];
-
+    
     /**
      * @var array Query purchaseStateParams
      */
@@ -285,7 +285,7 @@ class Constants
         'JUST_PURCHASED' => 'just_purchased',
         'OVERAGE' => 'overage',
     ];
-
+    
     /**
      * The size of the asset, indicating whether it is the free
      * complementary size or the original full-sized asset.
@@ -295,7 +295,7 @@ class Constants
         'Comp' => 'Comp',
         'Original' => 'Original',
     ];
-
+    
     /**
      * @var array searchParamLicenseThumbSizes
      */
@@ -316,7 +316,7 @@ class Constants
     {
         return static::$_queryParamsProps;
     }
-
+    
     /**
      * Getter for HttpMethod.
      * @return array
@@ -325,7 +325,7 @@ class Constants
     {
         return static::$_http_method;
     }
-
+    
     /**
      * Getter for Environment.
      * @return array
@@ -334,7 +334,7 @@ class Constants
     {
         return static::$_environments;
     }
-
+    
     /**
      * Getter for EndPoints.
      * @return array
@@ -343,7 +343,7 @@ class Constants
     {
         return static::$_end_points;
     }
-
+    
     /**
      * Getter for Asset Premium level.
      * @return array
@@ -352,7 +352,7 @@ class Constants
     {
         return static::$_assetPremiumLevel;
     }
-
+    
     /**
      * Getter for Asset Type.
      * @return array
@@ -370,7 +370,7 @@ class Constants
     {
         return static::$_searchParamsOrders;
     }
-
+    
     /**
      * Getter for SearchParamsOrientation.
      * @return array
@@ -379,7 +379,7 @@ class Constants
     {
         return static::$_searchParamsOrientation;
     }
-
+    
     /**
      * Getter for SearchParamsHasReleases.
      * @return array
@@ -388,7 +388,7 @@ class Constants
     {
         return static::$_SearchParamsHasReleases;
     }
-
+    
     /**
      * Getter for SearchParams3DTypes.
      * @return string
@@ -397,7 +397,7 @@ class Constants
     {
         return static::$_searchParams3DTypes;
     }
-
+    
     /**
      * Getter for SearchParamsTemplateCategories.
      * @return array
@@ -406,7 +406,7 @@ class Constants
     {
         return static::$_searchParamsTemplateCategories;
     }
-
+    
     /**
      * Getter for Query Param Props.
      * @return array
@@ -415,7 +415,7 @@ class Constants
     {
         return static::$_searchParamsTemplateTypes;
     }
-
+    
     /**
      * Getter for SearchParamsThumbSizes.
      * @return array
@@ -424,7 +424,7 @@ class Constants
     {
         return static::$_searchParamsThumbSizes;
     }
-
+    
     /**
      * Getter for SearchParamsAge.
      * @return array
@@ -433,7 +433,7 @@ class Constants
     {
         return static::$_searchParamsAge;
     }
-
+    
     /**
      * Getter for SearchParamsVideoDuration.
      * @return array
@@ -442,7 +442,7 @@ class Constants
     {
         return static::$_searchParamsVideoDuration;
     }
-
+    
     /**
      * Getter for SearchParamsType.
      * @return array
@@ -451,7 +451,7 @@ class Constants
     {
         return static::$_searchParamsType;
     }
-
+    
     /**
      * Getter for SearchParamsPremium.
      * @return array
@@ -469,7 +469,7 @@ class Constants
     {
         return static::$_resultColumns;
     }
-
+    
     /**
      * Getter for LicenseStateParams.
      * @return array
@@ -478,7 +478,7 @@ class Constants
     {
         return static::$_licenseStateParams;
     }
-
+    
     /**
      * Getter for PurchaseStateParams.
      * @return array
@@ -487,7 +487,7 @@ class Constants
     {
         return static::$_purchaseStateParams;
     }
-
+    
     /**
      * Getter for assest license size.
      * @return array of asset License Size
@@ -496,7 +496,7 @@ class Constants
     {
         return static::$_asset_license_size;
     }
-
+    
     /**
      * Getter for SearchParamsThumbSizes.
      * @return array

--- a/src/Request/Files.php
+++ b/src/Request/Files.php
@@ -41,7 +41,6 @@ class Files
     /**
      * @param array $ids
      * @return Files
-     * @throws StockApiException
      */
     public function setIds(array $ids) : Files
     {
@@ -62,7 +61,6 @@ class Files
      * Setter for Locale.
      * @param string $locale Language location code.
      * @return Files
-     * @throws StockApiException
      */
     public function setLocale(string $locale) : Files
     {
@@ -83,7 +81,6 @@ class Files
      * Set ResultColumns array consisting of result column constants
      * @param array $result_columns
      * @return Files
-     * @throws StockApiException
      */
     public function setResultColumns(array $result_columns) : Files
     {

--- a/src/Request/Files.php
+++ b/src/Request/Files.php
@@ -6,6 +6,8 @@
  * of the License at http://www.apache.org/licenses/LICENSE-2.0
  */
 
+declare(strict_types=1);
+
 namespace AdobeStock\Api\Request;
 
 use \AdobeStock\Api\Core\Constants;
@@ -14,7 +16,7 @@ use \AdobeStock\Api\Exception\StockApi as StockApiException;
 class Files
 {
     /**
-     * @var string File ids comma separated
+     * @var array File ids comma separated
      */
     private $ids;
 
@@ -29,23 +31,20 @@ class Files
     private $result_columns;
 
     /**
-     * @return string
+     * @return array
      */
-    public function getIds() : ?string
+    public function getIds() : ?array
     {
         return $this->ids;
     }
 
     /**
-     * @param string|null $ids
+     * @param array $ids
      * @return Files
      * @throws StockApiException
      */
-    public function setIds(string $ids = null) : Files
+    public function setIds(array $ids) : Files
     {
-        if ($ids == null) {
-            throw StockApiException::withMessage('Ids cannot be null');
-        }
         $this->ids = $ids;
         return $this;
     }
@@ -65,11 +64,8 @@ class Files
      * @return Files
      * @throws StockApiException
      */
-    public function setLocale(string $locale = null) : Files
+    public function setLocale(string $locale) : Files
     {
-        if ($locale == null) {
-            throw StockApiException::withMessage('Locale cannot be null');
-        }
         $this->locale = $locale;
         return $this;
     }
@@ -89,11 +85,8 @@ class Files
      * @return Files
      * @throws StockApiException
      */
-    public function setResultColumns(array $result_columns = null) : Files
+    public function setResultColumns(array $result_columns) : Files
     {
-        if (empty($result_columns)) {
-            throw StockApiException::withMessage('ResultColumns array cannot be empty');
-        }
         $this->result_columns = $result_columns;
         return $this;
     }
@@ -106,7 +99,7 @@ class Files
     public function toArray()
     {
         return [
-            Constants::getQueryParamsProps()['IDS'] => $this->ids,
+            Constants::getQueryParamsProps()['IDS'] => implode(',', $this->ids),
             Constants::getQueryParamsProps()['LOCALE'] => $this->locale,
             Constants::getQueryParamsProps()['RESULT_COLUMNS'] => $this->result_columns
         ];

--- a/src/Request/Files.php
+++ b/src/Request/Files.php
@@ -8,7 +8,7 @@
 
 namespace AdobeStock\Api\Request;
 
-use AdobeStock\Api\Core\Constants;
+use \AdobeStock\Api\Core\Constants;
 use \AdobeStock\Api\Exception\StockApi as StockApiException;
 
 class Files

--- a/src/Request/Files.php
+++ b/src/Request/Files.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * Copyright 2017 Adobe Systems Incorporated. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+namespace AdobeStock\Api\Request;
+
+use AdobeStock\Api\Core\Constants;
+use \AdobeStock\Api\Exception\StockApi as StockApiException;
+
+class Files
+{
+    /**
+     * @var string File ids comma separated
+     */
+    private $ids;
+
+    /**
+     * @var string Language location code
+     */
+    private $locale;
+
+    /**
+     * @var array result column constants
+     */
+    private $result_columns;
+
+    /**
+     * @return string
+     */
+    public function getIds() : ?string
+    {
+        return $this->ids;
+    }
+
+    /**
+     * @param string|null $ids
+     * @return Files
+     * @throws StockApiException
+     */
+    public function setIds(string $ids = null) : Files
+    {
+        if ($ids == null) {
+            throw StockApiException::withMessage('Ids cannot be null');
+        }
+        $this->ids = $ids;
+        return $this;
+    }
+
+    /**
+     * Getter for Locale.
+     * @return string|null Language location code.
+     */
+    public function getLocale() : ?string
+    {
+        return $this->locale;
+    }
+
+    /**
+     * Setter for Locale.
+     * @param string $locale Language location code.
+     * @return Files
+     * @throws StockApiException
+     */
+    public function setLocale(string $locale = null) : Files
+    {
+        if ($locale == null) {
+            throw StockApiException::withMessage('Locale cannot be null');
+        }
+        $this->locale = $locale;
+        return $this;
+    }
+
+    /**
+     * Get ResultColumns array that you have included for columns
+     * @return array|null
+     */
+    public function getResultColumns() : ?array
+    {
+        return $this->result_columns;
+    }
+
+    /**
+     * Set ResultColumns array consisting of result column constants
+     * @param array $result_columns
+     * @return Files
+     * @throws StockApiException
+     */
+    public function setResultColumns(array $result_columns = null) : Files
+    {
+        if (empty($result_columns)) {
+            throw StockApiException::withMessage('ResultColumns array cannot be empty');
+        }
+        $this->result_columns = $result_columns;
+        return $this;
+    }
+
+    /**
+     * Transforms object to array
+     *
+     * @return array
+     */
+    public function toArray()
+    {
+        return [
+            Constants::getQueryParamsProps()['IDS'] => $this->ids,
+            Constants::getQueryParamsProps()['LOCALE'] => $this->locale,
+            Constants::getQueryParamsProps()['RESULT_COLUMNS'] => $this->result_columns
+        ];
+    }
+}

--- a/src/Response/Files.php
+++ b/src/Response/Files.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * Copyright 2017 Adobe Systems Incorporated. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+namespace AdobeStock\Api\Response;
+
+use AdobeStock\Api\Models\StockFile;
+
+class Files
+{
+    /**
+     * @var int nb_results
+     */
+    public $nb_results;
+
+    /**
+     * @var StockFile[] array of StockFile
+     */
+    public $files;
+
+    /**
+     * Default Constructor function.
+     */
+    public function __construct()
+    {
+        $this->nb_results = null;
+        $this->files = [];
+    }
+
+    /**
+     * InitializeResponse function for Files
+     * @param array $raw_response Array contains value of various keys of Files Class
+     */
+    public function initializeResponse(array $raw_response) : void
+    {
+        foreach ($raw_response as $key => $val) {
+            if (property_exists($this, $key)) {
+                if (is_array($val) && $key == 'files') {
+                    $result_array_objects = [];
+                    foreach ($val as $element) {
+                        $result_array_objects[] = new StockFile($element);
+                    }
+                    $this->files = $result_array_objects;
+                } else {
+                    $this->$key = $val;
+                }
+            }
+        }
+    }
+
+    /**
+     * Get total number of found assets in the response.
+     *
+     * @return int|null
+     */
+    public function getNbResults() : ?int
+    {
+        return $this->nb_results;
+    }
+
+    /**
+     * Sets total number of found assets in the response.
+     *
+     * @param int $nb_results passed value for no of assets
+     * @return Files
+     */
+    public function setNbResults(int $nb_results = null) : Files
+    {
+        $this->nb_results = $nb_results;
+        return $this;
+    }
+
+    /**
+     * Get list of stock media files
+     *
+     * @return StockFile[]
+     */
+    public function getFiles() : array
+    {
+        return $this->files;
+    }
+
+    /**
+     * Sets list of stock media files.
+     *
+     * @param StockFile[] $files
+     * @return Files
+     */
+    public function setFiles(array $files) : Files
+    {
+        $this->files = $files;
+        return $this;
+    }
+}

--- a/src/Response/Files.php
+++ b/src/Response/Files.php
@@ -8,7 +8,7 @@
 
 namespace AdobeStock\Api\Response;
 
-use AdobeStock\Api\Models\StockFile;
+use \AdobeStock\Api\Models\StockFile;
 
 class Files
 {

--- a/test/src/Api/Client/AdobeStockTest.php
+++ b/test/src/Api/Client/AdobeStockTest.php
@@ -10,9 +10,11 @@ namespace AdobeStock\Api\Test;
 
 use \AdobeStock\Api\Client\AdobeStock;
 use \AdobeStock\Api\Request\SearchCategory as SearchCategoryRequest;
+use \AdobeStock\Api\Request\Files as FilesRequest;
 use \PHPUnit\Framework\TestCase;
 use \AdobeStock\Api\Client\Http\HttpClient;
 use \AdobeStock\Api\Response\SearchCategory as SearchCategoryResponse;
+use \AdobeStock\Api\Response\Files as FilesResponse;
 use \AdobeStock\Api\Response\SearchFiles as SearchFilesResponse;
 use \AdobeStock\Api\Core\Constants as CoreConstants;
 use \AdobeStock\Api\Request\SearchFiles as SearchFilesRequest;
@@ -53,13 +55,33 @@ class AdobeStockTest extends TestCase
         $request = new SearchCategoryRequest();
         $request->setCategoryId(11);
         $response = new SearchCategoryResponse(json_decode($raw_response, true));
-        
+
         $external_mock = \Mockery::mock('overload:AdobeStock\Api\Client\SearchCategory');
         $external_mock->shouldReceive('getCategory')->once()->andReturn($response);
-        
+
         $adobe_client = new \AdobeStock\Api\Client\AdobeStock('APIKey', 'Product', 'STAGE', $this->createMock(HttpClient::class));
         $adobe_client->searchCategory($request, '');
         $this->assertEquals($response, $adobe_client->searchCategory($request, ''));
+    }
+
+    /**
+     * @test
+     */
+    public function getFilesShouldReturnFilesResponse() : void
+    {
+        $requestMock = $this->createMock(FilesRequest::class);
+        $responseMock = $this->createMock(FilesResponse::class);
+
+        $external_mock = \Mockery::mock('overload:AdobeStock\Api\Client\Files');
+        $external_mock->shouldReceive('getFiles')->once()->andReturn($responseMock);
+
+        $adobe_client = new \AdobeStock\Api\Client\AdobeStock(
+            'APIKey',
+            'Product',
+            'STAGE',
+            null
+        );
+        $this->assertEquals($responseMock, $adobe_client->getFiles($requestMock, ''));
     }
 
     /**
@@ -77,10 +99,10 @@ class AdobeStockTest extends TestCase
         $request->setCategoryId(11);
         $response = new SearchCategoryResponse(json_decode($raw_response, true));
         $response_array[] = $response;
-        
+
         $external_mock = \Mockery::mock('overload:AdobeStock\Api\Client\SearchCategory');
         $external_mock->shouldReceive('getCategoryTree')->once()->andReturn($response_array);
-        
+
         $adobe_client = new \AdobeStock\Api\Client\AdobeStock('APIKey', 'Product', 'STAGE', null);
         $adobe_client->searchCategoryTree($request, '');
         $this->assertEquals($response_array, $adobe_client->searchCategoryTree($request, ''));
@@ -94,7 +116,7 @@ class AdobeStockTest extends TestCase
         $results_columns = CoreConstants::getResultColumns();
         $search_params = new SearchParametersModels();
         $search_params->setWords('tree')->setLimit(3)->setOffset(0);
-        
+
         $result_column_array = [
             $results_columns['NB_RESULTS'],
             $results_columns['COUNTRY_NAME'],
@@ -135,14 +157,14 @@ class AdobeStockTest extends TestCase
 
         $response = new SearchFilesResponse();
         $response->initializeResponse($raw_response);
-    
+
         $external_mock = \Mockery::mock('overload:AdobeStock\Api\Client\SearchFiles');
         $external_mock->shouldReceive('getNextResponse')->once()->andReturn($response);
-    
+
         $adobe_client = new \AdobeStock\Api\Client\AdobeStock('APIKey', 'Product', 'STAGE', null);
         $this->assertEquals($response, $adobe_client->getNextResponse());
     }
-    
+
     /**
      * @test
      */
@@ -172,7 +194,7 @@ class AdobeStockTest extends TestCase
         $adobe_client = new \AdobeStock\Api\Client\AdobeStock('APIKey', 'Product', 'STAGE', null);
         $this->assertEquals($response, $adobe_client->getPreviousResponse());
     }
-    
+
     /**
      * @test
      */
@@ -199,7 +221,7 @@ class AdobeStockTest extends TestCase
         $response->initializeResponse($raw_response);
         $external_mock = \Mockery::mock('overload:AdobeStock\Api\Client\SearchFiles');
         $external_mock->shouldReceive('getLastResponse')->once()->andReturn($response);
-        
+
         $adobe_client = new \AdobeStock\Api\Client\AdobeStock('APIKey', 'Product', 'STAGE', null);
         $this->assertEquals($response, $adobe_client->getLastResponse());
     }
@@ -229,11 +251,11 @@ class AdobeStockTest extends TestCase
         $response->initializeResponse($raw_response);
         $external_mock = \Mockery::mock('overload:AdobeStock\Api\Client\SearchFiles');
         $external_mock->shouldReceive('getResponsePage')->once()->andReturn($response);
-        
+
         $adobe_client = new \AdobeStock\Api\Client\AdobeStock('APIKey', 'Product', 'STAGE', null);
         $this->assertEquals($response, $adobe_client->getResponsePage(1));
     }
-    
+
     /**
      * @test
      */
@@ -242,11 +264,11 @@ class AdobeStockTest extends TestCase
         $total_files = 5716623;
         $external_mock = \Mockery::mock('overload:AdobeStock\Api\Client\SearchFiles');
         $external_mock->shouldReceive('totalSearchFiles')->once()->andReturn($total_files);
-        
+
         $adobe_client = new \AdobeStock\Api\Client\AdobeStock('APIKey', 'Product', 'STAGE', null);
         $this->assertEquals($total_files, $adobe_client->totalSearchFiles());
     }
-    
+
     /**
      * @test
      */
@@ -255,11 +277,11 @@ class AdobeStockTest extends TestCase
         $total_pages = 1905541;
         $external_mock = \Mockery::mock('overload:AdobeStock\Api\Client\SearchFiles');
         $external_mock->shouldReceive('totalSearchPages')->once()->andReturn($total_pages);
-        
+
         $adobe_client = new \AdobeStock\Api\Client\AdobeStock('APIKey', 'Product', 'STAGE', null);
         $this->assertEquals($total_pages, $adobe_client->totalSearchPages());
     }
-    
+
     /**
      * @test
      */
@@ -268,11 +290,11 @@ class AdobeStockTest extends TestCase
         $current_page = 1;
         $external_mock = \Mockery::mock('overload:AdobeStock\Api\Client\SearchFiles');
         $external_mock->shouldReceive('currentSearchPageIndex')->once()->andReturn($current_page);
-        
+
         $adobe_client = new \AdobeStock\Api\Client\AdobeStock('APIKey', 'Product', 'STAGE', null);
         $this->assertEquals($current_page, $adobe_client->currentSearchPageIndex());
     }
-    
+
     /**
      * @test
      */
@@ -296,14 +318,14 @@ class AdobeStockTest extends TestCase
         $request->setContentId(59741022);
         $request->setLicenseState('STANDARD');
         $response = new LicenseResponse(json_decode($raw_response, true));
-        
+
         $external_mock = \Mockery::mock('overload:AdobeStock\Api\Client\License');
         $external_mock->shouldReceive('getContentInfo')->once()->andReturn($response);
-        
+
         $adobe_client = new \AdobeStock\Api\Client\AdobeStock('APIKey', 'Product', 'STAGE', null);
         $this->assertEquals($response, $adobe_client->getContentInfo($request, ''));
     }
-    
+
     /**
      * @test
      */
@@ -330,14 +352,14 @@ class AdobeStockTest extends TestCase
         $request->setContentId(84071201);
         $request->setLicenseState('STANDARD');
         $response = new LicenseResponse(json_decode($raw_response, true));
-        
+
         $external_mock = \Mockery::mock('overload:AdobeStock\Api\Client\License');
         $external_mock->shouldReceive('getContentLicense')->once()->andReturn($response);
-        
+
         $adobe_client = new \AdobeStock\Api\Client\AdobeStock('APIKey', 'Product', 'STAGE', null);
         $this->assertEquals($response, $adobe_client->getContentLicense($request, ''));
     }
-    
+
     /**
      * @test
      */
@@ -361,14 +383,14 @@ class AdobeStockTest extends TestCase
         $request->setContentId(84071201);
         $request->setLicenseState('STANDARD');
         $response = new LicenseResponse(json_decode($raw_response, true));
-        
+
         $external_mock = \Mockery::mock('overload:AdobeStock\Api\Client\License');
         $external_mock->shouldReceive('getMemberProfile')->once()->andReturn($response);
-        
+
         $adobe_client = new \AdobeStock\Api\Client\AdobeStock('APIKey', 'Product', 'STAGE', null);
         $this->assertEquals($response, $adobe_client->getMemberProfile($request, ''));
     }
-    
+
     /**
      * @test
      */
@@ -376,14 +398,14 @@ class AdobeStockTest extends TestCase
     {
         $request = new LicenseRequest();
         $request->setContentId(84071201);
-        
+
         $external_mock = \Mockery::mock('overload:AdobeStock\Api\Client\License');
         $external_mock->shouldReceive('abandonLicense')->once()->andReturn(204);
-        
+
         $adobe_client = new \AdobeStock\Api\Client\AdobeStock('APIKey', 'Product', 'STAGE', null);
         $this->assertEquals(204, $adobe_client->abandonLicense($request, ''));
     }
-    
+
     /**
      * @test
      */
@@ -392,15 +414,15 @@ class AdobeStockTest extends TestCase
         $request = new LicenseRequest();
         $request->setContentId(59741022);
         $request->setLicenseState('STANDARD');
-        
+
         $guzzle_request = new Request('GET', 'TEST');
         $external_mock = \Mockery::mock('overload:AdobeStock\Api\Client\License');
         $external_mock->shouldReceive('downloadAssetRequest')->once()->andReturn($guzzle_request);
-        
+
         $adobe_client = new \AdobeStock\Api\Client\AdobeStock('APIKey', 'Product', 'STAGE', null);
         $this->assertEquals($guzzle_request, $adobe_client->downloadAssetRequest($request, ''));
     }
-    
+
     /**
      * @test
      */
@@ -409,14 +431,14 @@ class AdobeStockTest extends TestCase
         $request = new LicenseRequest();
         $request->setContentId(59741022);
         $request->setLicenseState('STANDARD');
-        
+
         $external_mock = \Mockery::mock('overload:AdobeStock\Api\Client\License');
         $external_mock->shouldReceive('downloadAssetUrl')->once()->andReturn('TEST');
-        
+
         $adobe_client = new \AdobeStock\Api\Client\AdobeStock('APIKey', 'Product', 'STAGE', null);
         $this->assertEquals('TEST', $adobe_client->downloadAssetUrl($request, ''));
     }
-    
+
     /**
      * @test
      */
@@ -425,10 +447,10 @@ class AdobeStockTest extends TestCase
         $request = new LicenseRequest();
         $request->setContentId(59741022);
         $request->setLicenseState('STANDARD');
-        
+
         $external_mock = \Mockery::mock('overload:AdobeStock\Api\Client\License');
         $external_mock->shouldReceive('downloadAssetStream')->once()->andReturn('image');
-        
+
         $adobe_client = new \AdobeStock\Api\Client\AdobeStock('APIKey', 'Product', 'STAGE', null);
         $this->assertEquals('image', $adobe_client->downloadAssetStream($request, ''));
     }
@@ -448,7 +470,7 @@ class AdobeStockTest extends TestCase
         $adobe_client = new AdobeStock('APIKey', 'Product', 'STAGE', null);
         $this->assertNotNull($adobe_client->initializeLicenseHistory($request, ''));
     }
-    
+
     /**
      * @test
      */
@@ -467,7 +489,7 @@ class AdobeStockTest extends TestCase
             ],
             ],
         ];
-        
+
         $response = new LicenseHistoryResponse();
         $response->initializeResponse($raw_response);
         $external_mock = \Mockery::mock('overload:AdobeStock\Api\Client\LicenseHistory');
@@ -475,7 +497,7 @@ class AdobeStockTest extends TestCase
         $adobe_client = new AdobeStock('APIKey', 'Product', 'STAGE', null);
         $this->assertEquals($response, $adobe_client->getNextLicenseHistory());
     }
-    
+
     /**
      * @test
      */
@@ -501,7 +523,7 @@ class AdobeStockTest extends TestCase
         $adobe_client = new AdobeStock('APIKey', 'Product', 'STAGE', null);
         $this->assertEquals($response, $adobe_client->getPreviousLicenseHistory());
     }
-    
+
     /**
      * @test
      */
@@ -527,7 +549,7 @@ class AdobeStockTest extends TestCase
         $adobe_client = new AdobeStock('APIKey', 'Product', 'STAGE', null);
         $this->assertEquals($response, $adobe_client->getLastLicenseHistory());
     }
-    
+
     /**
      * @test
      */
@@ -546,7 +568,7 @@ class AdobeStockTest extends TestCase
             ],
             ],
         ];
-        
+
         $response = new LicenseHistoryResponse();
         $response->initializeResponse($raw_response);
         $external_mock = \Mockery::mock('overload:AdobeStock\Api\Client\LicenseHistory');
@@ -554,7 +576,7 @@ class AdobeStockTest extends TestCase
         $adobe_client = new AdobeStock('APIKey', 'Product', 'STAGE', null);
         $this->assertEquals($response, $adobe_client->getLicenseHistoryPage(1));
     }
-    
+
     /**
      * @test
      */
@@ -566,7 +588,7 @@ class AdobeStockTest extends TestCase
         $adobe_client = new AdobeStock('APIKey', 'Product', 'STAGE', null);
         $this->assertEquals($total_files, $adobe_client->getTotalLicenseHistoryFiles());
     }
-    
+
     /**
      * @test
      */
@@ -578,7 +600,7 @@ class AdobeStockTest extends TestCase
         $adobe_client = new AdobeStock('APIKey', 'Product', 'STAGE', null);
         $this->assertEquals($total_files, $adobe_client->getTotalLicenseHistoryPages());
     }
-    
+
     /**
      * @test
      */

--- a/test/src/Api/Client/AdobeStockTest.php
+++ b/test/src/Api/Client/AdobeStockTest.php
@@ -55,10 +55,10 @@ class AdobeStockTest extends TestCase
         $request = new SearchCategoryRequest();
         $request->setCategoryId(11);
         $response = new SearchCategoryResponse(json_decode($raw_response, true));
-
+        
         $external_mock = \Mockery::mock('overload:AdobeStock\Api\Client\SearchCategory');
         $external_mock->shouldReceive('getCategory')->once()->andReturn($response);
-
+        
         $adobe_client = new \AdobeStock\Api\Client\AdobeStock('APIKey', 'Product', 'STAGE', $this->createMock(HttpClient::class));
         $adobe_client->searchCategory($request, '');
         $this->assertEquals($response, $adobe_client->searchCategory($request, ''));
@@ -99,10 +99,10 @@ class AdobeStockTest extends TestCase
         $request->setCategoryId(11);
         $response = new SearchCategoryResponse(json_decode($raw_response, true));
         $response_array[] = $response;
-
+        
         $external_mock = \Mockery::mock('overload:AdobeStock\Api\Client\SearchCategory');
         $external_mock->shouldReceive('getCategoryTree')->once()->andReturn($response_array);
-
+        
         $adobe_client = new \AdobeStock\Api\Client\AdobeStock('APIKey', 'Product', 'STAGE', null);
         $adobe_client->searchCategoryTree($request, '');
         $this->assertEquals($response_array, $adobe_client->searchCategoryTree($request, ''));
@@ -116,7 +116,7 @@ class AdobeStockTest extends TestCase
         $results_columns = CoreConstants::getResultColumns();
         $search_params = new SearchParametersModels();
         $search_params->setWords('tree')->setLimit(3)->setOffset(0);
-
+        
         $result_column_array = [
             $results_columns['NB_RESULTS'],
             $results_columns['COUNTRY_NAME'],
@@ -157,14 +157,14 @@ class AdobeStockTest extends TestCase
 
         $response = new SearchFilesResponse();
         $response->initializeResponse($raw_response);
-
+    
         $external_mock = \Mockery::mock('overload:AdobeStock\Api\Client\SearchFiles');
         $external_mock->shouldReceive('getNextResponse')->once()->andReturn($response);
-
+    
         $adobe_client = new \AdobeStock\Api\Client\AdobeStock('APIKey', 'Product', 'STAGE', null);
         $this->assertEquals($response, $adobe_client->getNextResponse());
     }
-
+    
     /**
      * @test
      */
@@ -194,7 +194,7 @@ class AdobeStockTest extends TestCase
         $adobe_client = new \AdobeStock\Api\Client\AdobeStock('APIKey', 'Product', 'STAGE', null);
         $this->assertEquals($response, $adobe_client->getPreviousResponse());
     }
-
+    
     /**
      * @test
      */
@@ -221,7 +221,7 @@ class AdobeStockTest extends TestCase
         $response->initializeResponse($raw_response);
         $external_mock = \Mockery::mock('overload:AdobeStock\Api\Client\SearchFiles');
         $external_mock->shouldReceive('getLastResponse')->once()->andReturn($response);
-
+        
         $adobe_client = new \AdobeStock\Api\Client\AdobeStock('APIKey', 'Product', 'STAGE', null);
         $this->assertEquals($response, $adobe_client->getLastResponse());
     }
@@ -251,11 +251,11 @@ class AdobeStockTest extends TestCase
         $response->initializeResponse($raw_response);
         $external_mock = \Mockery::mock('overload:AdobeStock\Api\Client\SearchFiles');
         $external_mock->shouldReceive('getResponsePage')->once()->andReturn($response);
-
+        
         $adobe_client = new \AdobeStock\Api\Client\AdobeStock('APIKey', 'Product', 'STAGE', null);
         $this->assertEquals($response, $adobe_client->getResponsePage(1));
     }
-
+    
     /**
      * @test
      */
@@ -264,11 +264,11 @@ class AdobeStockTest extends TestCase
         $total_files = 5716623;
         $external_mock = \Mockery::mock('overload:AdobeStock\Api\Client\SearchFiles');
         $external_mock->shouldReceive('totalSearchFiles')->once()->andReturn($total_files);
-
+        
         $adobe_client = new \AdobeStock\Api\Client\AdobeStock('APIKey', 'Product', 'STAGE', null);
         $this->assertEquals($total_files, $adobe_client->totalSearchFiles());
     }
-
+    
     /**
      * @test
      */
@@ -277,11 +277,11 @@ class AdobeStockTest extends TestCase
         $total_pages = 1905541;
         $external_mock = \Mockery::mock('overload:AdobeStock\Api\Client\SearchFiles');
         $external_mock->shouldReceive('totalSearchPages')->once()->andReturn($total_pages);
-
+        
         $adobe_client = new \AdobeStock\Api\Client\AdobeStock('APIKey', 'Product', 'STAGE', null);
         $this->assertEquals($total_pages, $adobe_client->totalSearchPages());
     }
-
+    
     /**
      * @test
      */
@@ -290,11 +290,11 @@ class AdobeStockTest extends TestCase
         $current_page = 1;
         $external_mock = \Mockery::mock('overload:AdobeStock\Api\Client\SearchFiles');
         $external_mock->shouldReceive('currentSearchPageIndex')->once()->andReturn($current_page);
-
+        
         $adobe_client = new \AdobeStock\Api\Client\AdobeStock('APIKey', 'Product', 'STAGE', null);
         $this->assertEquals($current_page, $adobe_client->currentSearchPageIndex());
     }
-
+    
     /**
      * @test
      */
@@ -318,14 +318,14 @@ class AdobeStockTest extends TestCase
         $request->setContentId(59741022);
         $request->setLicenseState('STANDARD');
         $response = new LicenseResponse(json_decode($raw_response, true));
-
+        
         $external_mock = \Mockery::mock('overload:AdobeStock\Api\Client\License');
         $external_mock->shouldReceive('getContentInfo')->once()->andReturn($response);
-
+        
         $adobe_client = new \AdobeStock\Api\Client\AdobeStock('APIKey', 'Product', 'STAGE', null);
         $this->assertEquals($response, $adobe_client->getContentInfo($request, ''));
     }
-
+    
     /**
      * @test
      */
@@ -352,14 +352,14 @@ class AdobeStockTest extends TestCase
         $request->setContentId(84071201);
         $request->setLicenseState('STANDARD');
         $response = new LicenseResponse(json_decode($raw_response, true));
-
+        
         $external_mock = \Mockery::mock('overload:AdobeStock\Api\Client\License');
         $external_mock->shouldReceive('getContentLicense')->once()->andReturn($response);
-
+        
         $adobe_client = new \AdobeStock\Api\Client\AdobeStock('APIKey', 'Product', 'STAGE', null);
         $this->assertEquals($response, $adobe_client->getContentLicense($request, ''));
     }
-
+    
     /**
      * @test
      */
@@ -383,14 +383,14 @@ class AdobeStockTest extends TestCase
         $request->setContentId(84071201);
         $request->setLicenseState('STANDARD');
         $response = new LicenseResponse(json_decode($raw_response, true));
-
+        
         $external_mock = \Mockery::mock('overload:AdobeStock\Api\Client\License');
         $external_mock->shouldReceive('getMemberProfile')->once()->andReturn($response);
-
+        
         $adobe_client = new \AdobeStock\Api\Client\AdobeStock('APIKey', 'Product', 'STAGE', null);
         $this->assertEquals($response, $adobe_client->getMemberProfile($request, ''));
     }
-
+    
     /**
      * @test
      */
@@ -398,14 +398,14 @@ class AdobeStockTest extends TestCase
     {
         $request = new LicenseRequest();
         $request->setContentId(84071201);
-
+        
         $external_mock = \Mockery::mock('overload:AdobeStock\Api\Client\License');
         $external_mock->shouldReceive('abandonLicense')->once()->andReturn(204);
-
+        
         $adobe_client = new \AdobeStock\Api\Client\AdobeStock('APIKey', 'Product', 'STAGE', null);
         $this->assertEquals(204, $adobe_client->abandonLicense($request, ''));
     }
-
+    
     /**
      * @test
      */
@@ -414,15 +414,15 @@ class AdobeStockTest extends TestCase
         $request = new LicenseRequest();
         $request->setContentId(59741022);
         $request->setLicenseState('STANDARD');
-
+        
         $guzzle_request = new Request('GET', 'TEST');
         $external_mock = \Mockery::mock('overload:AdobeStock\Api\Client\License');
         $external_mock->shouldReceive('downloadAssetRequest')->once()->andReturn($guzzle_request);
-
+        
         $adobe_client = new \AdobeStock\Api\Client\AdobeStock('APIKey', 'Product', 'STAGE', null);
         $this->assertEquals($guzzle_request, $adobe_client->downloadAssetRequest($request, ''));
     }
-
+    
     /**
      * @test
      */
@@ -431,14 +431,14 @@ class AdobeStockTest extends TestCase
         $request = new LicenseRequest();
         $request->setContentId(59741022);
         $request->setLicenseState('STANDARD');
-
+        
         $external_mock = \Mockery::mock('overload:AdobeStock\Api\Client\License');
         $external_mock->shouldReceive('downloadAssetUrl')->once()->andReturn('TEST');
-
+        
         $adobe_client = new \AdobeStock\Api\Client\AdobeStock('APIKey', 'Product', 'STAGE', null);
         $this->assertEquals('TEST', $adobe_client->downloadAssetUrl($request, ''));
     }
-
+    
     /**
      * @test
      */
@@ -447,10 +447,10 @@ class AdobeStockTest extends TestCase
         $request = new LicenseRequest();
         $request->setContentId(59741022);
         $request->setLicenseState('STANDARD');
-
+        
         $external_mock = \Mockery::mock('overload:AdobeStock\Api\Client\License');
         $external_mock->shouldReceive('downloadAssetStream')->once()->andReturn('image');
-
+        
         $adobe_client = new \AdobeStock\Api\Client\AdobeStock('APIKey', 'Product', 'STAGE', null);
         $this->assertEquals('image', $adobe_client->downloadAssetStream($request, ''));
     }
@@ -470,7 +470,7 @@ class AdobeStockTest extends TestCase
         $adobe_client = new AdobeStock('APIKey', 'Product', 'STAGE', null);
         $this->assertNotNull($adobe_client->initializeLicenseHistory($request, ''));
     }
-
+    
     /**
      * @test
      */
@@ -489,7 +489,7 @@ class AdobeStockTest extends TestCase
             ],
             ],
         ];
-
+        
         $response = new LicenseHistoryResponse();
         $response->initializeResponse($raw_response);
         $external_mock = \Mockery::mock('overload:AdobeStock\Api\Client\LicenseHistory');
@@ -497,7 +497,7 @@ class AdobeStockTest extends TestCase
         $adobe_client = new AdobeStock('APIKey', 'Product', 'STAGE', null);
         $this->assertEquals($response, $adobe_client->getNextLicenseHistory());
     }
-
+    
     /**
      * @test
      */
@@ -523,7 +523,7 @@ class AdobeStockTest extends TestCase
         $adobe_client = new AdobeStock('APIKey', 'Product', 'STAGE', null);
         $this->assertEquals($response, $adobe_client->getPreviousLicenseHistory());
     }
-
+    
     /**
      * @test
      */
@@ -549,7 +549,7 @@ class AdobeStockTest extends TestCase
         $adobe_client = new AdobeStock('APIKey', 'Product', 'STAGE', null);
         $this->assertEquals($response, $adobe_client->getLastLicenseHistory());
     }
-
+    
     /**
      * @test
      */
@@ -568,7 +568,7 @@ class AdobeStockTest extends TestCase
             ],
             ],
         ];
-
+        
         $response = new LicenseHistoryResponse();
         $response->initializeResponse($raw_response);
         $external_mock = \Mockery::mock('overload:AdobeStock\Api\Client\LicenseHistory');
@@ -576,7 +576,7 @@ class AdobeStockTest extends TestCase
         $adobe_client = new AdobeStock('APIKey', 'Product', 'STAGE', null);
         $this->assertEquals($response, $adobe_client->getLicenseHistoryPage(1));
     }
-
+    
     /**
      * @test
      */
@@ -588,7 +588,7 @@ class AdobeStockTest extends TestCase
         $adobe_client = new AdobeStock('APIKey', 'Product', 'STAGE', null);
         $this->assertEquals($total_files, $adobe_client->getTotalLicenseHistoryFiles());
     }
-
+    
     /**
      * @test
      */
@@ -600,7 +600,7 @@ class AdobeStockTest extends TestCase
         $adobe_client = new AdobeStock('APIKey', 'Product', 'STAGE', null);
         $this->assertEquals($total_files, $adobe_client->getTotalLicenseHistoryPages());
     }
-
+    
     /**
      * @test
      */

--- a/test/src/Api/Client/FilesFactoryTest.php
+++ b/test/src/Api/Client/FilesFactoryTest.php
@@ -10,7 +10,7 @@ namespace AdobeStock\Api\Test;
 
 use \AdobeStock\Api\Client\Files as FilesFactory;
 use \AdobeStock\Api\Core\Config as CoreConfig;
-use PHPUnit\Framework\MockObject\MockObject;
+use \PHPUnit\Framework\MockObject\MockObject;
 use \PHPUnit\Framework\TestCase;
 use \AdobeStock\Api\Request\Files as FilesRequest;
 use \AdobeStock\Api\Client\Http\HttpClient;

--- a/test/src/Api/Client/FilesFactoryTest.php
+++ b/test/src/Api/Client/FilesFactoryTest.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * Copyright 2017 Adobe Systems Incorporated. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+namespace AdobeStock\Api\Test;
+
+use \AdobeStock\Api\Client\Files as FilesFactory;
+use \AdobeStock\Api\Core\Config as CoreConfig;
+use PHPUnit\Framework\MockObject\MockObject;
+use \PHPUnit\Framework\TestCase;
+use \AdobeStock\Api\Request\Files as FilesRequest;
+use \AdobeStock\Api\Client\Http\HttpClient;
+use \GuzzleHttp\Psr7;
+
+class FilesFactoryTest extends TestCase
+{
+    /**
+     * Files API object.
+     * @var FilesFactory
+     */
+    private $_files_factory;
+
+    /**
+     * Config to be initialized.
+     * @var CoreConfig
+     */
+    private $_config;
+
+    /**
+     * Mocked HttpClient.
+     * @var MockObject HttpClient.
+     */
+    private $_mocked_http_client;
+
+    /**
+     * @test
+     * @before
+     */
+    public function initializeConstructorOfFilesFactory() : void
+    {
+        $this->_mocked_http_client = $this->createMock(HttpClient::class);
+        $this->_config = new CoreConfig('APIKey', 'Product', 'STAGE');
+        $this->_files_factory = new FilesFactory($this->_config);
+        $this->assertInstanceOf(FilesFactory::class, $this->_files_factory);
+    }
+
+    /**
+     * @test
+     */
+    public function getFilesShouldReturnValidResponse() : void
+    {
+        $requestMock = $this->createMock(FilesRequest::class);
+        $requestMock->method('toArray')->willReturn([]);
+        $this->_mocked_http_client->method('doGet')->willReturn(Psr7\stream_for('{
+            "nb_results":3,
+            "files":[{"id":281266321},{"id":285285249},{"id":264874647}]
+        }'));
+        $response = $this->_files_factory->getFiles($requestMock, $this->_mocked_http_client, '');
+        $this->assertEquals(3, $response->getNbResults());
+        $this->assertTrue(is_array($response->getFiles()));
+    }
+
+    /**
+     * @test
+     * @expectedException \AdobeStock\Api\Exception\StockApi
+     */
+    public function getFilesShouldThrowExceptionWhenAccessTokenIsNullWithIsLicensedColumn() : void
+    {
+        $requestMock = $this->createMock(FilesRequest::class);
+        $requestMock->method('getResultColumns')->willReturn(['is_licensed']);
+        $this->_files_factory->getFiles($requestMock, $this->_mocked_http_client);
+    }
+}

--- a/test/src/Api/Request/FilesRequestTest.php
+++ b/test/src/Api/Request/FilesRequestTest.php
@@ -8,7 +8,7 @@
 
 namespace AdobeStock\Api\Test;
 
-use AdobeStock\Api\Core\Constants;
+use \AdobeStock\Api\Core\Constants;
 use \PHPUnit\Framework\TestCase;
 use \AdobeStock\Api\Request\Files as FilesRequest;
 

--- a/test/src/Api/Request/FilesRequestTest.php
+++ b/test/src/Api/Request/FilesRequestTest.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * Copyright 2017 Adobe Systems Incorporated. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+namespace AdobeStock\Api\Test;
+
+use AdobeStock\Api\Core\Constants;
+use \PHPUnit\Framework\TestCase;
+use \AdobeStock\Api\Request\Files as FilesRequest;
+
+class FilesRequestTest extends TestCase
+{
+    /**
+     * Request object for Files API.
+     *
+     * @var FilesRequest
+     */
+    private $_request;
+
+    /**
+     * @test
+     * @before
+     */
+    public function initializeConstructorOfFilesRequest() : void
+    {
+        $this->_request = new FilesRequest();
+        $this->assertInstanceOf(FilesRequest::class, $this->_request);
+    }
+
+    /**
+     * @test
+     */
+    public function testAllTheGettersSettersReturnandSetTheProperValue() : void
+    {
+        $result_column_array = [
+            'nb_results',
+            'country_name',
+            'id',
+        ];
+        $this->_request->setIds('1,2,3');
+        $this->assertEquals('1,2,3', $this->_request->getIds());
+        $this->_request->setLocale('En-US');
+        $this->assertEquals('En-US', $this->_request->getLocale());
+        $this->_request->setResultColumns($result_column_array);
+        $this->assertEquals($result_column_array, $this->_request->getResultColumns());
+    }
+
+    /**
+     * @test
+     */
+    public function testToArrayReturnsValidArray() : void
+    {
+        $result_column_array = [
+            'nb_results',
+            'country_name',
+            'id',
+        ];
+        $this->_request->setIds('1,2,3');
+        $this->_request->setLocale('En-US');
+        $this->_request->setResultColumns($result_column_array);
+        $this->assertEquals([
+            Constants::getQueryParamsProps()['IDS'] => '1,2,3',
+            Constants::getQueryParamsProps()['LOCALE'] => 'En-US',
+            Constants::getQueryParamsProps()['RESULT_COLUMNS'] => $result_column_array
+        ], $this->_request->toArray());
+    }
+
+
+
+    /**
+     * @test
+     * @expectedException \AdobeStock\Api\Exception\StockApi
+     */
+    public function setIdsThrowException()
+    {
+        $this->_request->setIds(null);
+    }
+
+    /**
+     * @test
+     * @expectedException \AdobeStock\Api\Exception\StockApi
+     */
+    public function setLocaleThrowException()
+    {
+        $this->_request->setLocale(null);
+    }
+
+    /**
+     * @test
+     * @expectedException \AdobeStock\Api\Exception\StockApi
+     */
+    public function setResultColumnsThrowException()
+    {
+        $this->_request->setResultColumns([]);
+    }
+}

--- a/test/src/Api/Request/FilesRequestTest.php
+++ b/test/src/Api/Request/FilesRequestTest.php
@@ -41,8 +41,8 @@ class FilesRequestTest extends TestCase
             'country_name',
             'id',
         ];
-        $this->_request->setIds('1,2,3');
-        $this->assertEquals('1,2,3', $this->_request->getIds());
+        $this->_request->setIds([1, 2, 3]);
+        $this->assertEquals([1, 2, 3], $this->_request->getIds());
         $this->_request->setLocale('En-US');
         $this->assertEquals('En-US', $this->_request->getLocale());
         $this->_request->setResultColumns($result_column_array);
@@ -59,7 +59,7 @@ class FilesRequestTest extends TestCase
             'country_name',
             'id',
         ];
-        $this->_request->setIds('1,2,3');
+        $this->_request->setIds([1, 2, 3]);
         $this->_request->setLocale('En-US');
         $this->_request->setResultColumns($result_column_array);
         $this->assertEquals([
@@ -73,7 +73,7 @@ class FilesRequestTest extends TestCase
 
     /**
      * @test
-     * @expectedException \AdobeStock\Api\Exception\StockApi
+     * @expectedException \TypeError
      */
     public function setIdsThrowException()
     {
@@ -82,7 +82,7 @@ class FilesRequestTest extends TestCase
 
     /**
      * @test
-     * @expectedException \AdobeStock\Api\Exception\StockApi
+     * @expectedException \TypeError
      */
     public function setLocaleThrowException()
     {
@@ -91,10 +91,10 @@ class FilesRequestTest extends TestCase
 
     /**
      * @test
-     * @expectedException \AdobeStock\Api\Exception\StockApi
+     * @expectedException \TypeError
      */
     public function setResultColumnsThrowException()
     {
-        $this->_request->setResultColumns([]);
+        $this->_request->setResultColumns(null);
     }
 }

--- a/test/src/Api/Response/FilesResponseTest.php
+++ b/test/src/Api/Response/FilesResponseTest.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Copyright 2017 Adobe Systems Incorporated. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+namespace AdobeStock\Api\Test;
+
+use \AdobeStock\Api\Response\Files as FilesResponse;
+use \PHPUnit\Framework\TestCase;
+
+class FilesResponseTest extends TestCase
+{
+    /**
+     * Response object for Files API.
+     *
+     * @var FilesResponse
+     */
+    private $_response;
+
+    /**
+     * @test
+     * @before
+     */
+    public function initializeConstructorOfFilesResponse() : void
+    {
+        $this->_response = new FilesResponse();
+        $this->assertInstanceOf(FilesResponse::class, $this->_response);
+    }
+    /**
+     * @test
+     */
+    public function testAllTheGettersSettersReturnandSetTheProperValue() : void
+    {
+        $this->_response->setNbResults(5);
+        $this->assertEquals(5, $this->_response->getNbResults());
+
+        $this->_response->setFiles([]);
+        $this->assertEquals([], $this->_response->getFiles());
+    }
+}


### PR DESCRIPTION
## Overview
The lib is missing the Files API (https://www.adobe.io/apis/creativecloud/stock/docs.html#!adobe/stock-api-docs/master/docs/api/19-bulk-metadata-files-reference.md), this PR implements the methods to allow users to call the Files API through this lib.

## Technical Changes
- Added objects Request\Files and Response\Files
- Added necessary values to the Constants class
- Created the Files Client that calls the API
- Added the method getFiles to the AdobeStock Client
- Added unit tests